### PR TITLE
Add get model command

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -26,7 +26,7 @@ func NewGetCmd(ctx context.Context, logger *logging.Logger) *GetCmd {
 
 	// add subcommands
 	modelCmd := newGetModelCmd(ctx, logger)
-	getCmd.AddCommand(modelCmd.Command())
+	getCmd.AddCommand(modelCmd.Command)
 
 	return c
 }
@@ -35,13 +35,13 @@ func (c *GetCmd) Command() *cobra.Command { return c.command }
 func (c *GetCmd) SetFlags()               {}
 func (c *GetCmd) Validate() error         { return nil }
 
-// get model command
-
+// get model command.
 type GetModelCmd struct {
-	command *cobra.Command
-	ctx     context.Context
-	logger  *logging.Logger
-	name    string
+	ctx    context.Context
+	logger *logging.Logger
+	name   string
+
+	Command *cobra.Command
 }
 
 func newGetModelCmd(ctx context.Context, logger *logging.Logger) *GetModelCmd {
@@ -53,20 +53,11 @@ func newGetModelCmd(ctx context.Context, logger *logging.Logger) *GetModelCmd {
 	}
 	cmd.Flags().StringVar(&g.name, "name", "", "Model name")
 	cmd.MarkFlagRequired("name")
-	g.command = cmd
+	g.Command = cmd
 	return g
 }
 
-func (g *GetModelCmd) Command() *cobra.Command { return g.command }
-func (g *GetModelCmd) SetFlags()               {}
-func (g *GetModelCmd) Validate() error {
-	if g.name == "" {
-		return fmt.Errorf("--name is required")
-	}
-	return nil
-}
-
-func (g *GetModelCmd) runE(cmd *cobra.Command, args []string) error {
+func (g *GetModelCmd) runE(_ *cobra.Command, _ []string) error {
 	client := anki.NewClient(Config.AnkiURL)
 
 	templates, err := client.GetModelTemplates(g.ctx, g.name)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -57,6 +57,12 @@ func newGetModelCmd(ctx context.Context, logger *logging.Logger) *GetModelCmd {
 	return g
 }
 
+	fields, err := client.GetModelFieldNames(g.ctx, g.name)
+	if err != nil {
+		return fmt.Errorf("get fields: %w", err)
+	}
+
+		InOrderFields: fields,
 func (g *GetModelCmd) runE(_ *cobra.Command, _ []string) error {
 	client := anki.NewClient(Config.AnkiURL)
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -57,14 +57,13 @@ func newGetModelCmd(ctx context.Context, logger *logging.Logger) *GetModelCmd {
 	return g
 }
 
+func (g *GetModelCmd) runE(_ *cobra.Command, _ []string) error {
+	client := anki.NewClient(Config.AnkiURL)
+
 	fields, err := client.GetModelFieldNames(g.ctx, g.name)
 	if err != nil {
 		return fmt.Errorf("get fields: %w", err)
 	}
-
-		InOrderFields: fields,
-func (g *GetModelCmd) runE(_ *cobra.Command, _ []string) error {
-	client := anki.NewClient(Config.AnkiURL)
 
 	templates, err := client.GetModelTemplates(g.ctx, g.name)
 	if err != nil {
@@ -78,15 +77,12 @@ func (g *GetModelCmd) runE(_ *cobra.Command, _ []string) error {
 
 	model := anki.Model{
 		Name:          g.name,
+		InOrderFields: fields,
 		CSS:           css,
 		CardTemplates: templates,
 	}
 
-	wrap := struct {
-		Models []anki.Model `yaml:"models"`
-	}{Models: []anki.Model{model}}
-
-	out, err := yaml.Marshal(wrap)
+	out, err := yaml.Marshal(model)
 	if err != nil {
 		return err
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/spigell/anki-sync/internal/anki"
+	"github.com/spigell/anki-sync/internal/logging"
+)
+
+// GetCmd represents the top level `get` command.
+type GetCmd struct {
+	command *cobra.Command
+}
+
+func NewGetCmd(ctx context.Context, logger *logging.Logger) *GetCmd {
+	getCmd := &cobra.Command{
+		Use:   "get",
+		Short: "Retrieve data from Anki",
+	}
+
+	c := &GetCmd{command: getCmd}
+
+	// add subcommands
+	modelCmd := newGetModelCmd(ctx, logger)
+	getCmd.AddCommand(modelCmd.Command())
+
+	return c
+}
+
+func (c *GetCmd) Command() *cobra.Command { return c.command }
+func (c *GetCmd) SetFlags()               {}
+func (c *GetCmd) Validate() error         { return nil }
+
+// get model command
+
+type GetModelCmd struct {
+	command *cobra.Command
+	ctx     context.Context
+	logger  *logging.Logger
+	name    string
+}
+
+func newGetModelCmd(ctx context.Context, logger *logging.Logger) *GetModelCmd {
+	g := &GetModelCmd{ctx: ctx, logger: logger}
+	cmd := &cobra.Command{
+		Use:   "model",
+		Short: "Get model templates and styling by name",
+		RunE:  g.runE,
+	}
+	cmd.Flags().StringVar(&g.name, "name", "", "Model name")
+	cmd.MarkFlagRequired("name")
+	g.command = cmd
+	return g
+}
+
+func (g *GetModelCmd) Command() *cobra.Command { return g.command }
+func (g *GetModelCmd) SetFlags()               {}
+func (g *GetModelCmd) Validate() error {
+	if g.name == "" {
+		return fmt.Errorf("--name is required")
+	}
+	return nil
+}
+
+func (g *GetModelCmd) runE(cmd *cobra.Command, args []string) error {
+	client := anki.NewClient(Config.AnkiURL)
+
+	templates, err := client.GetModelTemplates(g.ctx, g.name)
+	if err != nil {
+		return fmt.Errorf("get templates: %w", err)
+	}
+
+	css, err := client.GetModelStyling(g.ctx, g.name)
+	if err != nil {
+		return fmt.Errorf("get styling: %w", err)
+	}
+
+	model := anki.Model{
+		Name:          g.name,
+		CSS:           css,
+		CardTemplates: templates,
+	}
+
+	wrap := struct {
+		Models []anki.Model `yaml:"models"`
+	}{Models: []anki.Model{model}}
+
+	out, err := yaml.Marshal(wrap)
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(string(out))
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ type ValidatedCommand interface {
 func NewRootCmd(ctx context.Context, logger *Logger) *cobra.Command {
 	commands := []ValidatedCommand{
 		NewSyncCmd(ctx, logger.Instance),
+		NewGetCmd(ctx, logger.Instance),
 		NewVersionCmd(ctx, logger.Instance.Logger),
 	}
 

--- a/internal/anki/client.go
+++ b/internal/anki/client.go
@@ -154,6 +154,23 @@ func (c *Client) GetModelStyling(ctx context.Context, name string) (string, erro
 	return result.CSS, nil
 }
 
+func (c *Client) GetModelFieldNames(ctx context.Context, name string) ([]string, error) {
+	var result []string
+
+	err := c.do(ctx, request{
+		Action:  "modelFieldNames",
+		Version: 6,
+		Params: map[string]string{
+			"modelName": name,
+		},
+	}, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (c *Client) DeckExists(ctx context.Context, name string) (bool, error) {
 	var result []string
 	err := c.do(ctx, request{

--- a/internal/anki/client.go
+++ b/internal/anki/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"sort"
 	"time"
 )
 
@@ -106,6 +107,51 @@ func (c *Client) UpdateModelStyling(ctx context.Context, name string, css string
 		Version: 6,
 		Params:  data,
 	}, nil)
+}
+
+func (c *Client) GetModelTemplates(ctx context.Context, name string) ([]CardTemplate, error) {
+	var result map[string]struct {
+		Front string `json:"Front"`
+		Back  string `json:"Back"`
+	}
+
+	err := c.do(ctx, request{
+		Action:  "modelTemplates",
+		Version: 6,
+		Params: map[string]string{
+			"modelName": name,
+		},
+	}, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	templates := make([]CardTemplate, 0, len(result))
+	for name, t := range result {
+		templates = append(templates, CardTemplate{Name: name, Front: t.Front, Back: t.Back})
+	}
+	sort.Slice(templates, func(i, j int) bool { return templates[i].Name < templates[j].Name })
+
+	return templates, nil
+}
+
+func (c *Client) GetModelStyling(ctx context.Context, name string) (string, error) {
+	var result struct {
+		CSS string `json:"css"`
+	}
+
+	err := c.do(ctx, request{
+		Action:  "modelStyling",
+		Version: 6,
+		Params: map[string]string{
+			"modelName": name,
+		},
+	}, &result)
+	if err != nil {
+		return "", err
+	}
+
+	return result.CSS, nil
 }
 
 func (c *Client) DeckExists(ctx context.Context, name string) (bool, error) {


### PR DESCRIPTION
## Summary
- add `get model` command to fetch templates and styling for a model
- support retrieving template & css via new AnkiConnect client helpers
- wire the new command into the CLI

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68458a11f1b4832fa11370c32025a44d